### PR TITLE
Refactor: Move handler! macro to core::handler module

### DIFF
--- a/src/core/handler.rs
+++ b/src/core/handler.rs
@@ -69,3 +69,33 @@ where
 {
     Arc::new(AsyncFnHandler(f))
 }
+
+/// Simplifies handler creation for synchronous builds.
+///
+/// This macro expands to a call to the `sync_h` helper function,
+/// which wraps the synchronous handler function to make it compatible
+/// with the server's unified handler system.
+#[cfg(feature = "sync")]
+#[macro_export]
+macro_rules! handler {
+    ($handler_fn:expr) => {
+        $crate::core::handler::sync_h($handler_fn)
+    };
+}
+
+/// Simplifies handler creation for asynchronous builds.
+///
+/// This macro expands to a call to the `async_h` helper function,
+/// wrapping the user's `async fn` in a closure that pins and boxes the
+/// future. This hides the necessary boilerplate from the user, providing
+/// a clean API.
+#[cfg(all(
+  any(feature = "async_tokio", feature = "async_std", feature = "async_smol"),
+  not(feature = "sync")
+))]
+#[macro_export]
+macro_rules! handler {
+    ($handler_fn:expr) => {
+        $crate::core::handler::async_h(move |req| Box::pin($handler_fn(req)))
+    };
+}

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,33 +1,3 @@
-/// Simplifies handler creation for synchronous builds.
-///
-/// This macro expands to a call to the `sync_h` helper function,
-/// which wraps the synchronous handler function to make it compatible
-/// with the server's unified handler system.
-#[macro_export]
-#[cfg(feature = "sync")]
-macro_rules! handler {
-    ($handler_fn:expr) => {
-        $crate::core::handler::sync_h($handler_fn)
-    };
-}
-
-/// Simplifies handler creation for asynchronous builds.
-///
-/// This macro expands to a call to the `async_h` helper function,
-/// wrapping the user's `async fn` in a closure that pins and boxes the
-/// future. This hides the necessary boilerplate from the user, providing
-/// a clean API.
-#[macro_export]
-#[cfg(all(
-  any(feature = "async_tokio", feature = "async_std", feature = "async_smol"),
-  not(feature = "sync")
-))]
-macro_rules! handler {
-    ($handler_fn:expr) => {
-        $crate::core::handler::async_h(move |req| Box::pin($handler_fn(req)))
-    };
-}
-
 /// Generates a `parse_stream` function for a specific async runtime.
 ///
 /// This macro abstracts the common logic of reading and parsing an HTTP request

--- a/src/runtime/async/tokio.rs
+++ b/src/runtime/async/tokio.rs
@@ -1,4 +1,4 @@
-use crate::core::request::{handle_request_async, Request};
+use crate::core::request::handle_request_async;
 use crate::core::request_handler::Rh;
 use crate::core::response::Response;
 use crate::runtime::r#async::shared;


### PR DESCRIPTION
Moved the `handler!` macro definitions from `src/macros.rs` to `src/core/handler.rs` to improve the logical structure of the codebase. The macro is now located in the same module as the helper functions it uses (`sync_h` and `async_h`).

The `#[macro_export]` attribute on the macro definition ensures it remains part of the crate's public API and is available for import via `use httpageboy::handler;`, preserving the existing API.

The now-unnecessary `#[macro_use]` attribute on the `macros` module import in `lib.rs` has been removed, and a minor unused import warning was also fixed during testing.